### PR TITLE
feat(tmux): hide battery segment on devices without a battery

### DIFF
--- a/terminals/tmux/tmux.conf
+++ b/terminals/tmux/tmux.conf
@@ -77,7 +77,8 @@ set -ga status-left '#{tmux_mode_indicator} '
 
 set -g  status-right '#{cpu_fg_color}#{cpu_icon}#{cpu_percentage} '
 set -ga status-right '#{ram_fg_color}#{ram_icon}#{ram_percentage} '
-set -ga status-right '#{battery_color_charge_fg}#[bg=default]#{battery_icon_charge} #{battery_percentage} '
+if-shell 'pmset -g batt 2>/dev/null | grep -q InternalBattery' \
+  'set -ga status-right "#{battery_color_charge_fg}#[bg=default]#{battery_icon_charge} #{battery_percentage} "'
 set -ga status-right '#[fg=brightmagenta,bg=default]  %a %b %d %I:%M%p'
 
 # Window 
@@ -190,6 +191,7 @@ set -g @resurrect-capture-pane-contents 'on'
 set -g @resurrect-strategy-nvim         'session'
 set -g @resurrect-processes             '\
   btop \
+  "~claude" \
   "~codex" \
   "~glow" \
   "~man" \

--- a/terminals/tmux/tmux.conf
+++ b/terminals/tmux/tmux.conf
@@ -191,7 +191,6 @@ set -g @resurrect-capture-pane-contents 'on'
 set -g @resurrect-strategy-nvim         'session'
 set -g @resurrect-processes             '\
   btop \
-  "~claude" \
   "~codex" \
   "~glow" \
   "~man" \


### PR DESCRIPTION
Conditionally shows the battery segment only on devices with an internal battery, using `pmset` to detect it.