### PR TITLE
style(icons): align glg command icon

### DIFF
--- a/cli/eza/theme.yml
+++ b/cli/eza/theme.yml
@@ -1197,12 +1197,8 @@ filenames:
       glyph: "󰊕"
 
   glg:
-    filename:
-      foreground: red
     icon:
-      glyph: ""
-      style:
-        foreground: red
+      glyph: "󰊕"
 
   l:
     icon:

--- a/editors/nvim/lua/plugins/webdevicons.lua
+++ b/editors/nvim/lua/plugins/webdevicons.lua
@@ -27,7 +27,7 @@ require('nvim-web-devicons').setup {
     ['cheatsheet'] = { icon = icons.command, name = 'cheatsheet' },
     ['edit-all'] = { icon = icons.command, name = 'edit-all' },
     ['fix-tmux-remotes'] = { icon = icons.command, name = 'fix-tmux-remotes' },
-    ['glg'] = { icon = icons.log, name = 'glg', color = thm.red },
+    ['glg'] = { icon = icons.command, name = 'glg' },
     ['l'] = { icon = icons.command, name = 'l' },
     ['list-256'] = { icon = icons.command, name = 'list-256' },
     ['list-colors'] = { icon = icons.command, name = 'list-colors' },


### PR DESCRIPTION
## Summary

- render `glg` with the same command icon as the other extensionless shell helpers
- remove the special red history/log styling in both nvim-web-devicons and eza

## Why

`glg` is a shell helper that displays Git history, but the local filename overrides classified the helper itself as a history/log file. Neither nvim-web-devicons nor eza has an upstream `glg` mapping; the inconsistent presentation came from these repo-specific overrides.

## Validation

- `./bootstrap.sh --check`
- `bash -n bootstrap.sh`
- `git diff --check upstream/main...HEAD`
- headless Neovim assertion for the `glg` devicon
- eza render assertion for `󰊕 glg`